### PR TITLE
add support for 'refer' parameter

### DIFF
--- a/src/SmsDev.php
+++ b/src/SmsDev.php
@@ -88,9 +88,10 @@ class SmsDev
      *
      * @param int $number Recipient's number.
      * @param string $message SMS message.
+     * @param string $refer  Optional. User reference for message identification.
      * @return bool true if the API accepted the request.
      */
-    public function send($number, $message)
+    public function send($number, $message, $refer = null)
     {
         $this->_result = [];
 
@@ -111,19 +112,23 @@ class SmsDev
             }
 
         }
-        
+
+        $params = [
+            'key'    => $this->_apiKey,
+            'type'   => 9,
+            'number' => $number,
+            'msg'    => $message,
+        ];
+
+        if ($refer) $params['refer'] = $refer;
+
         $request = new Request(
             'POST',
             $this->_apiUrl.'/send',
             [
                 'Accept' => 'application/json',
             ],
-            json_encode([
-                'key'    => $this->_apiKey,
-                'type'   => 9,
-                'number' => $number,
-                'msg'    => $message,
-            ])
+            json_encode($params)
         );
 
         if ($this->makeRequest($request) === false) return false;

--- a/tests/ApiRequestsTest.php
+++ b/tests/ApiRequestsTest.php
@@ -41,6 +41,25 @@ final class ApiRequestsTest extends SmsDevMock
         $this->assertEquals('Message',       $query->msg);
     }
 
+    public function testSendWithRefer()
+    {
+        $SmsDev = $this->getServiceMock();
+
+        $SmsDev->setNumberValidation(false);
+
+        $SmsDev->send('5511988887777', 'Message', 'Refer string');
+
+        $this->assertSame('/v1/send', $this->getRequestPath());
+
+        $query = $this->getRequestBody();
+
+        $this->assertEquals('',              $query->key);
+        $this->assertEquals('9',             $query->type);
+        $this->assertEquals('5511988887777', $query->number);
+        $this->assertEquals('Message',       $query->msg);
+        $this->assertEquals('Refer string',  $query->refer);
+    }
+
     public function testFilterByUnread()
     {
         $SmsDev = $this->getServiceMock();

--- a/tests/ApiResponseTest.php
+++ b/tests/ApiResponseTest.php
@@ -30,13 +30,17 @@ final class ApiResponseTest extends SmsDevMock
     /**
      * @dataProvider sendDataProvider
      */
-    public function testSend($number, $message, $expectedResponse, $apiResponse)
+    public function testSend($number, $message, $refer, $expectedResponse, $apiResponse)
     {
         $SmsDev = $this->getServiceMock($apiResponse);
 
         $SmsDev->setNumberValidation(false);
 
-        $this->assertSame($expectedResponse, $SmsDev->send($number, $message));
+        if ($refer) {
+            $this->assertSame($expectedResponse, $SmsDev->send($number, $message, $refer));
+        } else {
+            $this->assertSame($expectedResponse, $SmsDev->send($number, $message));
+        }
     }
 
     /**
@@ -46,13 +50,19 @@ final class ApiResponseTest extends SmsDevMock
     {
         return [
 
-            // number,         message,     expectedResponse,   apiResponse
-            [ '1188881000',   'Message',    true,               '{"situacao": "OK", "codigo": "1", "id": "637849052", "descricao": "MENSAGEM NA FILA" }' ],
-            [ '1188881000',   '',           false,              '{"situacao":"ERRO","codigo":"400","descricao":"MENSAGEM NAO DEFINIDA."}' ],
-            [ '118888100',    'Message',    true,               '{"situacao":"OK","codigo":"1","id":"645106333","descricao":"MENSAGEM NA FILA"}' ],
-            [ '11888810009',  'Message',    true,               '{"situacao":"OK","codigo":"1","id":"645106334","descricao":"MENSAGEM NA FILA"}' ],
-            [ 'abc',          'Message',    false,              '{"situacao":"ERRO","codigo":"402","descricao":"SEM NUMERO DESTINATARIO."}' ],
-            [ '',             'Message',    false,              '{"situacao":"ERRO","codigo":"402","descricao":"SEM NUMERO DESTINATARIO."}' ],
+            // number,         message,     refer       expectedResponse,   apiResponse
+            [ '1188881000',   'Message',    null,       true,               '{"situacao": "OK", "codigo": "1", "id": "637849052", "descricao": "MENSAGEM NA FILA" }' ],
+            [ '1188881000',   '',           null,       false,              '{"situacao":"ERRO","codigo":"400","descricao":"MENSAGEM NAO DEFINIDA."}' ],
+            [ '118888100',    'Message',    null,       true,               '{"situacao":"OK","codigo":"1","id":"645106333","descricao":"MENSAGEM NA FILA"}' ],
+            [ '11888810009',  'Message',    null,       true,               '{"situacao":"OK","codigo":"1","id":"645106334","descricao":"MENSAGEM NA FILA"}' ],
+            [ 'abc',          'Message',    null,       false,              '{"situacao":"ERRO","codigo":"402","descricao":"SEM NUMERO DESTINATARIO."}' ],
+            [ '',             'Message',    null,       false,              '{"situacao":"ERRO","codigo":"402","descricao":"SEM NUMERO DESTINATARIO."}' ],
+            [ '1188881000',   'Message',    'Refer',    true,               '{"situacao": "OK", "codigo": "1", "id": "637849052", "refer": "Refer", "descricao": "MENSAGEM NA FILA"}' ],
+            [ '1188881000',   '',           'Refer',    false,              '{"situacao":"ERRO","codigo":"400","refer": "Refer","descricao":"MENSAGEM NAO DEFINIDA."}' ],
+            [ '118888100',    'Message',    'Refer',    true,               '{"situacao":"OK","codigo":"1","id":"645106333","refer": "Refer","descricao":"MENSAGEM NA FILA"}' ],
+            [ '11888810009',  'Message',    'Refer',    true,               '{"situacao":"OK","codigo":"1","id":"645106334","refer": "Refer","descricao":"MENSAGEM NA FILA"}' ],
+            [ 'abc',          'Message',    'Refer',    false,              '{"situacao":"ERRO","codigo":"402","refer": "Refer","descricao":"SEM NUMERO DESTINATARIO."}' ],
+            [ '',             'Message',    'Refer',    false,              '{"situacao":"ERRO","codigo":"402","refer": "Refer","descricao":"SEM NUMERO DESTINATARIO."}'],   
 
         ];
     }


### PR DESCRIPTION
Hi, I started using this SDK and noticed that there is no support for the 'refer' parameter when sending an SMS.
I would like to use this parameter so I made a simple change to the `SmsDev::send` method to be able to include this value on SMS sending operation.

To be consistent with the API documentation [here](https://www.smsdev.com.br/en/envio-sms/), the method parameter is optional. Thus, both examples below works.

```php
# as before
$SmsDev->send(5511988881111, 'SMS Message');

# including refer
$SmsDev->send(5511988881111, 'SMS Message', 'Refer');
```

I am doing this PR to help improve this library. If you find this feature fit to this library, please accept my PR or suggest changes.